### PR TITLE
use smartmatch to compare paths

### DIFF
--- a/t/01-file-find.t
+++ b/t/01-file-find.t
@@ -5,13 +5,13 @@ plan 10;
 
 my $res = find(:dir<t/dir1>);
 my @test = $res.map({ .Str }).sort;
-is @test, <t/dir1/another_dir t/dir1/another_dir/empty_file t/dir1/another_dir/file.bar t/dir1/file.bar t/dir1/file.foo t/dir1/foodir t/dir1/foodir/not_a_dir>, 'just a dir';
+equals @test, <t/dir1/another_dir t/dir1/another_dir/empty_file t/dir1/another_dir/file.bar t/dir1/file.bar t/dir1/file.foo t/dir1/foodir t/dir1/foodir/not_a_dir>, 'just a dir';
 
 # names
 
 $res = find(:dir<t/dir1>, :name(/foo/));
 @test = $res.map({ .Str }).sort;
-is @test, <t/dir1/file.foo t/dir1/foodir t/dir1/foodir/not_a_dir>, 'name with regex';
+equals @test, <t/dir1/file.foo t/dir1/foodir t/dir1/foodir/not_a_dir>, 'name with regex';
 
 # (default) recursive find
 
@@ -30,15 +30,15 @@ is $res.elems, 0, 'no results';
 
 $res = find(:dir<t/dir1>, :type<dir>);
 @test = $res.map({ .Str }).sort;
-is @test, <t/dir1/another_dir t/dir1/foodir>, 'types: dir';
+equals @test, <t/dir1/another_dir t/dir1/foodir>, 'types: dir';
 
 $res = find(:dir<t/dir1>, :type<dir>, :name(/foo/));
 @test = $res.map({ .Str }).sort;
-is @test, <t/dir1/foodir>, 'types: dir, combined with name';
+equals @test, <t/dir1/foodir>, 'types: dir, combined with name';
 
 $res = find(:dir<t/dir1>, :type<file>, :name(/foo/));
 @test = $res.map({ .Str }).sort;
-is @test, <t/dir1/file.foo t/dir1/foodir/not_a_dir>,
+equals @test, <t/dir1/file.foo t/dir1/foodir/not_a_dir>,
 	'types: file, combined with name';
 
 #keep-going
@@ -69,6 +69,10 @@ if 0 {
     is $res.elems, 1, 'found one of two files due to X::IO::Dir';
 
     LEAVE { &dir.unwrap($w); }
+}
+
+sub equals(\a, \b, $name) {
+    ok ([&&] a >>~~<< b.map(*.path)), $name
 }
 
 exit 0; # I have no idea what I'm doing, but I get Non-zero exit status w/o this


### PR DESCRIPTION
Be aware that this will only work on a rakudo as of today or newer.
But without this patch the tests will fail on Win32 and panda will do like nothing. So bumping the submodule version in panda is also needed.
