### PR TITLE
Convert forward slashes to backslashes on windows

### DIFF
--- a/lib/File/Find.pm
+++ b/lib/File/Find.pm
@@ -37,7 +37,7 @@ sub find (:$dir!, :$name, :$type, :$exclude = False, Bool :$recursive = True,
         my $elem = @targets.shift;
         # exclude is special because it also stops traversing inside,
         # which checkrules does not
-        next if $elem ~~ $exclude;
+        next if $elem ~~ $exclude.IO.relative;
         take $elem if checkrules($elem, { :$name, :$type, :$exclude });
         if $recursive {
             if $elem.IO ~~ :d {


### PR DESCRIPTION
This fixes panda on windows.