### PR TITLE
Add unit declarator to module declarations

### DIFF
--- a/lib/File/Find.pm
+++ b/lib/File/Find.pm
@@ -1,6 +1,6 @@
 use v6;
 
-module File::Find;
+unit module File::Find;
 
 sub checkrules ($elem, %opts) {
     if %opts<name>.defined {


### PR DESCRIPTION
As of Rakudo 2015.05, the `unit` declarator is required before using
`module`, `class` or `grammar` declarations (unless it uses a block).  Code
still using the old blockless semicolon form will throw a warning. This
commit stops the warning from appearing in the new Rakudo.